### PR TITLE
Safely check if options.iframe is a DOM element

### DIFF
--- a/js/Duo-Web-v2.js
+++ b/js/Duo-Web-v2.js
@@ -214,7 +214,7 @@ window.Duo = (function(document, window) {
             }
 
             if (options.iframe) {
-                if ('tagName' in options.iframe) {
+                if (options.iframe.tagName) {
                     iframe = options.iframe;
                 } else if (typeof options.iframe === 'string') {
                     iframeId = options.iframe;


### PR DESCRIPTION
When integrating the Duo Web SDK in my application, I've noticed that passing an `iframe` ID string to `Duo.init` causes the application to reliably throw because of an unsafe attempt to access the `tagName` property to check whether `options.iframe` is a DOM element or a DOM element ID:

```
TypeError: invalid 'in' operand options.iframe
```

This PR swaps `if ('tagName' in options.iframe)` for `if (options.iframe.tagName)`. The former will always throw on string inputs (can be tested independently in a Node shell), while the latter will return `undefined` if the `tagName` property does not exist. This can be done safely on string inputs.

Please note that the minified client library (`Duo-Web-v2.min.js`) should be updated as well, but this project's `package.json` doesn't specify any minification build scripts, so changes to the minified script are not included in this PR.